### PR TITLE
diff highlight

### DIFF
--- a/crates/oyui-tasker/derive/lib.rs
+++ b/crates/oyui-tasker/derive/lib.rs
@@ -246,6 +246,11 @@ pub fn tasker_registry(input: TokenStream) -> TokenStream {
         }
 
         impl EventSender {
+            pub fn new_dummy() -> Self {
+                let (tx, _) = ::tokio::sync::mpsc::unbounded_channel();
+                Self { tx }
+            }
+
             pub fn send<E>(&self, event: E) -> Result<(), ::tokio::sync::mpsc::error::SendError<Event>>
             where
                 Event: From<E>,

--- a/crates/oyui/src/actions/define.rs
+++ b/crates/oyui/src/actions/define.rs
@@ -68,6 +68,10 @@ define_actions! {
             fold {
                 toggle(),
             },
+            inline_diff {
+                toggle(),
+                set(bool),
+            },
             close(),
         },
         tree {

--- a/crates/oyui/src/actions/handlers/mod.rs
+++ b/crates/oyui/src/actions/handlers/mod.rs
@@ -3,6 +3,7 @@ use crate::actions::*;
 use crate::diff_cache::DiffCache;
 use crate::tree::FileTree;
 use crate::view::View;
+use crate::worker::EventSender;
 use parking_lot::RwLock;
 use std::sync::Arc;
 
@@ -16,6 +17,8 @@ pub struct AppActionsHandler {
     pub tree: Arc<RwLock<FileTree>>,
     pub cache: Arc<RwLock<DiffCache>>,
     pub view: View,
+    pub inline_diff: Arc<RwLock<bool>>,
+    pub worker: EventSender,
 }
 
 pub fn generate(
@@ -23,12 +26,16 @@ pub fn generate(
     tree: Arc<RwLock<FileTree>>,
     cache: Arc<RwLock<DiffCache>>,
     view: View,
+    inline_diff: Arc<RwLock<bool>>,
+    worker: EventSender,
 ) -> BoxedHandler {
     let handler = AppActionsHandler {
         state,
         tree,
         cache,
         view,
+        inline_diff,
+        worker,
     };
     Handler {
         global: handler.clone(),
@@ -63,6 +70,7 @@ pub fn generate(
         view_file_nav: handler.clone(),
         view_file_staging: handler.clone(),
         view_file_fold: handler.clone(),
+        view_file_inline_diff: handler.clone(),
         view_tree: handler.clone(),
         view_tree_cursor: handler.clone(),
         view_tree_directory: handler.clone(),

--- a/crates/oyui/src/actions/handlers/view_handlers/file_handler/mod.rs
+++ b/crates/oyui/src/actions/handlers/view_handlers/file_handler/mod.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use crate::actions::handlers::AppActionsHandler;
 use crate::actions::*;
 use crate::diff_cache::DiffCache;
+use crate::tree::TreeNode;
+use crate::worker::tasks;
 
 pub mod file_staging_handler;
 
@@ -239,5 +241,55 @@ impl ViewFileFoldActionsHandler for AppActionsHandler {
             let next_offset = Some(next_selected.saturating_sub(ctx.cursor_screen_offset));
             update_scroll_state(&mut view, &ctx.path, next_selected, next_offset);
         }
+    }
+}
+
+impl ViewFileInlineDiffActionsHandler for AppActionsHandler {
+    fn toggle(&self) {
+        let enabled = {
+            let mut flag = self.inline_diff.write();
+            *flag = !*flag;
+            *flag
+        };
+        tracing::debug!(enabled, "Toggled inline diff");
+
+        let path = self.view.file_view.read().current_path.clone();
+        if let Some(path) = path {
+            self.cache.write().diffs.mark_started(path.clone());
+
+            let tree_read = self.tree.read();
+            fn find_paths(
+                nodes: &[TreeNode],
+                path: &std::path::Path,
+            ) -> Option<(Option<std::path::PathBuf>, Option<std::path::PathBuf>)> {
+                for node in nodes {
+                    match node {
+                        TreeNode::File(f) => {
+                            if f.path == path {
+                                return Some((f.left_path.clone(), f.right_path.clone()));
+                            }
+                        }
+                        TreeNode::Directory(d) => {
+                            if let Some(paths) = find_paths(&d.children, path) {
+                                return Some(paths);
+                            }
+                        }
+                    }
+                }
+                None
+            }
+            if let Some((left_path, right_path)) = find_paths(&tree_read.nodes, &path) {
+                let _ = self.worker.send(tasks::full_diff::FullDiffReq {
+                    node_path: path,
+                    left_path,
+                    right_path,
+                });
+            }
+        }
+    }
+
+    fn set(&self, val: bool) {
+        *self.inline_diff.write() = val;
+        tracing::debug!(val, "Set inline diff");
     }
 }

--- a/crates/oyui/src/actions/keybinds.rs
+++ b/crates/oyui/src/actions/keybinds.rs
@@ -4,8 +4,9 @@ use std::rc::Rc;
 
 use crate::actions::{
     Action, GlobalActions, ViewFileActions, ViewFileCursorActions, ViewFileFoldActions,
-    ViewFileNavActions, ViewFileScrollActions, ViewFileStagingActions, ViewTreeActions,
-    ViewTreeCursorActions, ViewTreeDirectoryActions, ViewTreeStagingActions,
+    ViewFileInlineDiffActions, ViewFileNavActions, ViewFileScrollActions,
+    ViewFileStagingActions, ViewTreeActions, ViewTreeCursorActions, ViewTreeDirectoryActions,
+    ViewTreeStagingActions,
 };
 use crate::commons::input::{Keybind, Keybinds};
 
@@ -231,6 +232,7 @@ pub fn default_keybinds() -> KeybindRegistry {
             .register(Keybinds::char('s'), ViewFileStagingActions::split)
             .register(Keybinds::char('i'), ViewFileStagingActions::invert)
             .register(Keybinds::char('z'), ViewFileFoldActions::toggle)
+            .register(Keybinds::char('d'), ViewFileInlineDiffActions::toggle)
         })
         .on_mode(KeybindMode::View(View::Tree), |r| {
             r.register(

--- a/crates/oyui/src/app/mod.rs
+++ b/crates/oyui/src/app/mod.rs
@@ -46,6 +46,8 @@ pub struct AppReq {
     pub config_error: Arc<RwLock<Option<String>>>,
     #[builder(default = Arc::new(RwLock::new(None)))]
     pub current_path: Arc<RwLock<Option<PathBuf>>>,
+    #[builder(default = Arc::new(RwLock::new(true)))]
+    pub inline_diff: Arc<RwLock<bool>>,
 
     pub config_path: PathBuf,
     pub worker: EventRegistry,
@@ -63,6 +65,7 @@ pub struct App {
     pub config_path: PathBuf,
     pub config_error: Arc<RwLock<Option<String>>>,
     pub current_path: Arc<RwLock<Option<PathBuf>>>,
+    pub inline_diff: Arc<RwLock<bool>>,
     pub worker: EventRegistry,
     pub left_path: PathBuf,
     pub right_path: PathBuf,
@@ -82,6 +85,8 @@ impl From<AppReq> for App {
             value.tree.clone(),
             value.cache.clone(),
             value.view.clone(),
+            value.inline_diff.clone(),
+            value.worker.sender(),
         );
 
         Self {
@@ -93,6 +98,7 @@ impl From<AppReq> for App {
             config_path: value.config_path,
             config_error: value.config_error,
             current_path: value.current_path,
+            inline_diff: value.inline_diff,
             worker: value.worker,
             left_path: value.left_path,
             right_path: value.right_path,

--- a/crates/oyui/src/commands/diff.rs
+++ b/crates/oyui/src/commands/diff.rs
@@ -21,10 +21,12 @@ pub async fn run_diff(
     let config_error = Arc::new(RwLock::new(None));
     let syntax_theme = Arc::new(RwLock::new(Lazy::Uninitialized));
     let current_path = Arc::new(RwLock::new(None));
+    let inline_diff = Arc::new(RwLock::new(true));
 
     let worker_context = AppWorkerContext::builder()
         .syntax_engine(SyntaxEngine::new())
         .algorithm(diff_args.diff_algorithm)
+        .inline_diff(inline_diff.clone())
         .config(opts.clone())
         .tree(tree.clone())
         .cache(cache.clone())
@@ -40,6 +42,7 @@ pub async fn run_diff(
 
     let mut app = App::builder()
         .worker(worker)
+        .inline_diff(inline_diff)
         .config_path(config_path)
         .config_error(config_error)
         .base_path(diff_args.base.clone())

--- a/crates/oyui/src/commands/language_server.rs
+++ b/crates/oyui/src/commands/language_server.rs
@@ -18,7 +18,14 @@ pub async fn run_lsp() -> Result<(), CommandError> {
     let cache = Arc::new(parking_lot::RwLock::new(DiffCache::default()));
     let view = View::default();
 
-    let handler = handlers::generate(state, tree, cache, view);
+    let handler = handlers::generate(
+        state,
+        tree,
+        cache,
+        view,
+        Arc::new(parking_lot::RwLock::new(true)),
+        crate::worker::EventSender::new_dummy(),
+    );
     let context = script::build_context(handler)
         .map_err(|e| CommandError::Runtime(Box::new(e)))?;
 

--- a/crates/oyui/src/view/file/render/line/text/mod.rs
+++ b/crates/oyui/src/view/file/render/line/text/mod.rs
@@ -106,22 +106,10 @@ impl<'a> TextRenderer<'a> {
             }
         };
 
-        let inline_bg: Color = if !self.is_staged {
-            if self.is_selected {
-                self.theme.cursor_bg.into()
-            } else {
-                self.theme.bg.into()
-            }
-        } else if self.is_selected {
-            if self.is_add {
-                lerp_color(self.theme.add_bg.into(), self.theme.add_fg.into(), 0.4)
-            } else {
-                lerp_color(self.theme.del_bg.into(), self.theme.del_fg.into(), 0.4)
-            }
-        } else if self.is_add {
-            lerp_color(self.theme.add_bg.into(), self.theme.add_fg.into(), 0.2)
+        let inline_bg: Color = if self.is_add {
+            lerp_color(self.theme.add_bg.into(), self.theme.bg.into(), 0.65)
         } else {
-            lerp_color(self.theme.del_bg.into(), self.theme.del_fg.into(), 0.2)
+            lerp_color(self.theme.del_bg.into(), self.theme.bg.into(), 0.65)
         };
 
         let crate::config::theme::Color::Rgb(fg_r, fg_g, fg_b) = self.theme.fg;
@@ -169,7 +157,12 @@ impl<'a> TextRenderer<'a> {
                 if let Some(hl) = active_hl {
                     let hl_end_in_token = (hl.byte_range.end.saturating_sub(text_start)).min(text.len());
                     if let Some(slice) = text.get(token_offset..hl_end_in_token) {
-                        push_slice(slice, base_style.bg(inline_bg), true);
+                        let hl_style = if self.is_selected {
+                            base_style.fg(self.theme.fg.into()).bg(inline_bg)
+                        } else {
+                            base_style.bg(inline_bg)
+                        };
+                        push_slice(slice, hl_style, true);
                     } else {
                         push_slice(&text[token_offset..], base_style, false);
                         break;

--- a/crates/oyui/src/worker/context.rs
+++ b/crates/oyui/src/worker/context.rs
@@ -15,6 +15,7 @@ pub struct AppWorkerContext {
     pub syntax_engine: SyntaxEngine,
     pub config: Opts,
     pub algorithm: DiffAlgorithm,
+    pub inline_diff: Arc<RwLock<bool>>,
 
     pub tree: Arc<RwLock<FileTree>>,
     pub cache: Arc<RwLock<DiffCache>>,

--- a/crates/oyui/src/worker/tasks/full_diff.rs
+++ b/crates/oyui/src/worker/tasks/full_diff.rs
@@ -108,11 +108,393 @@ impl<'a> LineIndex<'a> {
     }
 }
 
+/// Merges overlapping or adjacent `InlineChange` byte ranges.
+fn merge_inline_changes(mut changes: Vec<InlineChange>) -> Vec<InlineChange> {
+    changes.sort_by_key(|c| c.byte_range.start);
+    let mut merged: Vec<InlineChange> = Vec::new();
+    for c in changes {
+        if let Some(last) = merged.last_mut() {
+            if c.byte_range.start <= last.byte_range.end {
+                last.byte_range.end = last.byte_range.end.max(c.byte_range.end);
+                continue;
+            }
+        }
+        merged.push(c);
+    }
+    merged
+}
+
+/// Whether `c` is treated as a word character.
+/// Unlike `is_alphanumeric`, underscore is NOT a word char so that
+/// `snake_case` identifiers split into separate tokens.
+fn is_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c > '\x7F'
+}
+
+/// Tokenize a byte range into line tokens (each line ending with `\n`).
+fn tokenize_lines(text: &str, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut line_start = range.start;
+    for (i, ch) in text[range.clone()].char_indices() {
+        let pos = range.start + i;
+        if ch == '\n' {
+            ranges.push(line_start..pos + 1);
+            line_start = pos + 1;
+        }
+    }
+    if line_start < range.end {
+        ranges.push(line_start..range.end);
+    }
+    ranges
+}
+
+/// Tokenize a byte range into word tokens (runs of word characters).
+/// Non-word characters are skipped.
+fn tokenize_words(text: &str, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut word_start: Option<usize> = None;
+    for (i, ch) in text[range.clone()].char_indices() {
+        let pos = range.start + i;
+        if is_word_char(ch) {
+            if word_start.is_none() {
+                word_start = Some(pos);
+            }
+        } else if let Some(start) = word_start.take() {
+            ranges.push(start..pos);
+        }
+    }
+    if let Some(start) = word_start {
+        ranges.push(start..range.end);
+    }
+    ranges
+}
+
+/// Tokenize a byte range into individual non-word characters.
+/// Word characters are skipped — they are handled at the word level.
+fn tokenize_nonwords(text: &str, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    for (i, ch) in text[range.clone()].char_indices() {
+        let pos = range.start + i;
+        if !is_word_char(ch) {
+            ranges.push(pos..pos + ch.len_utf8());
+        }
+    }
+    ranges
+}
+
+/// A token source backed by a `&str` and a pre-computed range list.
+struct StrTokenSource<'a> {
+    text: &'a str,
+    ranges: Vec<Range<usize>>,
+}
+
+impl<'a> imara_diff::TokenSource for StrTokenSource<'a> {
+    type Token = String;
+    type Tokenizer = Box<dyn Iterator<Item = String> + 'a>;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        let text = self.text;
+        let ranges = self.ranges.clone();
+        Box::new(ranges.into_iter().map(move |r| text[r].to_string()))
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        self.ranges.len() as u32
+    }
+}
+
+/// Run a single-level histogram diff of `old[left]` vs `new[right]`.
+///
+/// Returns matching `(old_range, new_range)` pairs.
+fn single_level_diff(
+    old: &str,
+    left: Range<usize>,
+    new: &str,
+    right: Range<usize>,
+    tokenizer: impl Fn(&str, Range<usize>) -> Vec<Range<usize>>,
+) -> Vec<(Range<usize>, Range<usize>)> {
+    let left_ranges = tokenizer(old, left);
+    let right_ranges = tokenizer(new, right);
+
+    if left_ranges.is_empty() || right_ranges.is_empty() {
+        return vec![];
+    }
+
+    let left_source = StrTokenSource { text: old, ranges: left_ranges.clone() };
+    let right_source = StrTokenSource { text: new, ranges: right_ranges.clone() };
+
+    let input = InternedInput::new(left_source, right_source);
+    let diff = Diff::compute(Algorithm::Histogram, &input);
+
+    let mut matches: Vec<(Range<usize>, Range<usize>)> = Vec::new();
+    let mut li = 0usize;
+    let mut ri = 0usize;
+
+    for hunk in diff.hunks() {
+        let l_end = hunk.before.end as usize;
+        let r_end = hunk.after.end as usize;
+        let l_start = hunk.before.start as usize;
+        let r_start = hunk.after.start as usize;
+
+        while li < l_start && ri < r_start {
+            matches.push((left_ranges[li].clone(), right_ranges[ri].clone()));
+            li += 1;
+            ri += 1;
+        }
+
+        li = l_end;
+        ri = r_end;
+    }
+
+    while li < left_ranges.len() && ri < right_ranges.len() {
+        matches.push((left_ranges[li].clone(), right_ranges[ri].clone()));
+        li += 1;
+        ri += 1;
+    }
+
+    matches
+}
+
+/// Refine existing matches by re-diffing each gap at a finer granularity.
+/// Returns a new match list with sub-matches inserted.
+fn refine_matches(
+    old: &str,
+    new: &str,
+    matches: &[(Range<usize>, Range<usize>)],
+    tokenizer: impl Fn(&str, Range<usize>) -> Vec<Range<usize>>,
+) -> Vec<(Range<usize>, Range<usize>)> {
+    let mut refined = Vec::with_capacity(matches.len());
+    refined.push(matches[0].clone());
+
+    for window in matches.windows(2) {
+        let (prev_left, prev_right) = &window[0];
+        let (next_left, next_right) = &window[1];
+
+        if prev_left.end < next_left.start && prev_right.end < next_right.start {
+            let gap_left = prev_left.end..next_left.start;
+            let gap_right = prev_right.end..next_right.start;
+            refined.extend(single_level_diff(old, gap_left, new, gap_right, &tokenizer));
+        }
+
+        refined.push((next_left.clone(), next_right.clone()));
+    }
+
+    refined
+}
+
+/// Computes multi-level (line → word → nonword) differences between two
+/// strings using jj-style histogram refinement.
+///
+/// Returns `(old_ranges, new_ranges)` where each range is a UTF-8-safe byte
+/// range within the respective string that differs between the old and new
+/// text.
+fn char_diff(old: &str, new: &str) -> (Vec<InlineChange>, Vec<InlineChange>) {
+    if old.is_empty() || new.is_empty() || old == new {
+        return (Vec::new(), Vec::new());
+    }
+
+    let len_old = old.len();
+    let len_new = new.len();
+
+    // Level 1: line-level diff
+    let raw = single_level_diff(old, 0..len_old, new, 0..len_new, tokenize_lines);
+
+    // Build match list with empty boundary sentinels
+    let mut matches: Vec<(Range<usize>, Range<usize>)> = Vec::with_capacity(raw.len() + 2);
+    matches.push((0..0, 0..0));
+    matches.extend(raw);
+    matches.push((len_old..len_old, len_new..len_new));
+
+    // Level 2: word-level refinement
+    matches = refine_matches(old, new, &matches, tokenize_words);
+
+    // Level 3: nonword-level refinement
+    matches = refine_matches(old, new, &matches, tokenize_nonwords);
+
+    // Convert gaps between final matches to removed/added ranges
+    let mut old_ranges = Vec::new();
+    let mut new_ranges = Vec::new();
+
+    for window in matches.windows(2) {
+        let (prev_left, prev_right) = &window[0];
+        let (next_left, next_right) = &window[1];
+
+        if prev_left.end < next_left.start {
+            old_ranges.push(InlineChange { byte_range: prev_left.end..next_left.start });
+        }
+        if prev_right.end < next_right.start {
+            new_ranges.push(InlineChange { byte_range: prev_right.end..next_right.start });
+        }
+    }
+
+    (
+        merge_inline_changes(old_ranges),
+        merge_inline_changes(new_ranges),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn char_diff_identical() {
+        let (old, new) = char_diff("hello", "hello");
+        assert!(old.is_empty());
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn char_diff_empty() {
+        let (old, new) = char_diff("", "hello");
+        assert!(old.is_empty());
+        assert!(new.is_empty());
+
+        let (old, new) = char_diff("hello", "");
+        assert!(old.is_empty());
+        assert!(new.is_empty());
+
+        let (old, new) = char_diff("", "");
+        assert!(old.is_empty());
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn char_diff_completely_different() {
+        let (old, new) = char_diff("abc", "xyz");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..3 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..3 }]);
+    }
+
+    #[test]
+    fn char_diff_partial_change() {
+        // Both are single word tokens → word-level mismatch, no nonword chars
+        // to refine → full word highlighted
+        let (old, new) = char_diff("foobar", "foobaz");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..6 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..6 }]);
+    }
+
+    #[test]
+    fn char_diff_insertion() {
+        let (old, new) = char_diff("abc", "abcxyz");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..3 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..6 }]);
+    }
+
+    #[test]
+    fn char_diff_deletion() {
+        let (old, new) = char_diff("abcxyz", "abc");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..6 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..3 }]);
+    }
+
+    #[test]
+    fn char_diff_prepend() {
+        let (old, new) = char_diff("abc", "xyzabc");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..3 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..6 }]);
+    }
+
+    #[test]
+    fn char_diff_unicode() {
+        // All chars are word chars (alphanumeric or non-ASCII) → no nonword refinement
+        let (old, new) = char_diff("café", "cafè");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..5 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..5 }]);
+    }
+
+    #[test]
+    fn char_diff_single_char() {
+        let (old, new) = char_diff("a", "b");
+        assert_eq!(old, vec![InlineChange { byte_range: 0..1 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 0..1 }]);
+    }
+
+    #[test]
+    fn char_diff_whitespace_indent() {
+        // "  foo" → "    foo": "foo" matches at word level.
+        // Nonword level matches individual spaces: 2 common, 2 extra at end.
+        let (old, new) = char_diff("  foo", "    foo");
+        assert!(old.is_empty());
+        assert_eq!(new, vec![InlineChange { byte_range: 2..4 }]);
+    }
+
+    #[test]
+    fn char_diff_whitespace_dedent() {
+        let (old, new) = char_diff("    foo", "  foo");
+        assert_eq!(old, vec![InlineChange { byte_range: 2..4 }]);
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn char_diff_multi_word() {
+        // "abc def ghi" → "abc xyz ghi": "abc" and "ghi" match at word level.
+        // Spaces around middle word match at nonword level.
+        // Only "def" vs "xyz" remains.
+        let (old, new) = char_diff("abc def ghi", "abc xyz ghi");
+        assert_eq!(old, vec![InlineChange { byte_range: 4..7 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 4..7 }]);
+    }
+
+    #[test]
+    fn char_diff_underscore_word() {
+        // Underscore breaks words, so foo_bar → foo_baz highlights only
+        // "bar" vs "baz", not the whole identifier.
+        let (old, new) = char_diff("fn foo_bar() {}", "fn foo_baz() {}");
+        assert_eq!(old, vec![InlineChange { byte_range: 7..10 }]);
+        assert_eq!(new, vec![InlineChange { byte_range: 7..10 }]);
+    }
+
+    #[test]
+    fn char_diff_leading_newline_skip() {
+        // old: "\n    foo" (newline + 4 spaces + foo)
+        // new: "\n  foo"   (newline + 2 spaces + foo)
+        // "foo" matches at word level. Newline and common spaces match
+        // at nonword level. Only the trailing 2 extra spaces highlight.
+        let (old, new) = char_diff("\n    foo", "\n  foo");
+        assert_eq!(old, vec![InlineChange { byte_range: 3..5 }]);
+        assert!(new.is_empty());
+    }
+
+    #[test]
+    fn tokenize_lines_basic() {
+        let tokens = tokenize_lines("abc\ndef\n", 0..8);
+        assert_eq!(tokens, vec![0..4, 4..8]);
+    }
+
+    #[test]
+    fn tokenize_words_basic() {
+        let tokens = tokenize_words("foo bar", 0..7);
+        assert_eq!(tokens, vec![0..3, 4..7]);
+    }
+
+    #[test]
+    fn tokenize_words_underscore() {
+        // Underscore is not a word char → splits the identifier
+        let tokens = tokenize_words("foo_bar", 0..7);
+        assert_eq!(tokens, vec![0..3, 4..7]);
+    }
+
+    #[test]
+    fn tokenize_nonwords_basic() {
+        let tokens = tokenize_nonwords("a b", 0..3);
+        assert_eq!(tokens, vec![1..2]);
+    }
+
+    #[test]
+    fn tokenize_nonwords_skips_word_chars() {
+        let tokens = tokenize_nonwords("abc", 0..3);
+        assert!(tokens.is_empty());
+    }
+}
+
 pub fn compute(
     algo: &DiffAlgorithm,
     left_text: &str,
     right_text: &str,
     path: &Path,
+    inline_diff: bool,
 ) -> Result<Vec<Hunk>, Box<dyn std::error::Error + Send + Sync>> {
     let input = InternedInput::new(left_text, right_text);
 
@@ -155,7 +537,7 @@ pub fn compute(
             let trimmed_len = line_text.trim().len();
 
             if trimmed_len == 0 {
-                return Vec::new(); 
+                return Vec::new();
             }
 
             if let Some(_syntax) = &syntax_res {
@@ -231,6 +613,152 @@ pub fn compute(
             });
         }
 
+        // Section-based block-diff: find consecutive -/+ groups and run
+        // char_diff on concatenated section text.
+        if inline_diff {
+            let mut si = 0;
+        while si < lines.len() {
+            while si < lines.len() && !matches!(lines[si], DiffLine::Deletion { .. }) {
+                si += 1;
+            }
+            if si >= lines.len() {
+                break;
+            }
+            let del_start = si;
+            let mut del_count = 0;
+            while si < lines.len() && matches!(lines[si], DiffLine::Deletion { .. }) {
+                del_count += 1;
+                si += 1;
+            }
+
+            let add_start = si;
+            let mut add_count = 0;
+            while si < lines.len() && matches!(lines[si], DiffLine::Addition { .. }) {
+                add_count += 1;
+                si += 1;
+            }
+
+            if del_count == 0 || add_count == 0 {
+                continue;
+            }
+
+            // Build concatenated old text and record per-line byte offsets
+            let mut old_concat = String::new();
+            let mut old_offsets: Vec<Range<usize>> = Vec::with_capacity(del_count);
+            for j in 0..del_count {
+                let line_idx = match &lines[del_start + j] {
+                    DiffLine::Deletion { old_line_idx, .. } => *old_line_idx,
+                    _ => unreachable!(),
+                };
+                let text = &left_text[old_idx.printable_byte_range(line_idx)];
+                if j > 0 {
+                    old_concat.push('\n');
+                }
+                let start = old_concat.len();
+                old_concat.push_str(text);
+                old_offsets.push(start..old_concat.len());
+            }
+
+            // Build concatenated new text and record per-line byte offsets
+            let mut new_concat = String::new();
+            let mut new_offsets: Vec<Range<usize>> = Vec::with_capacity(add_count);
+            for j in 0..add_count {
+                let line_idx = match &lines[add_start + j] {
+                    DiffLine::Addition { new_line_idx, .. } => *new_line_idx,
+                    _ => unreachable!(),
+                };
+                let text = &right_text[new_idx.printable_byte_range(line_idx)];
+                if j > 0 {
+                    new_concat.push('\n');
+                }
+                let start = new_concat.len();
+                new_concat.push_str(text);
+                new_offsets.push(start..new_concat.len());
+            }
+
+            // Run char_diff on concatenated section texts
+            let (old_changes, new_changes) = char_diff(&old_concat, &new_concat);
+
+            // Distribute old ranges to individual deletion lines
+            let mut old_pending: Vec<Vec<InlineChange>> = (0..del_count).map(|_| Vec::new()).collect();
+            for change in &old_changes {
+                let r = &change.byte_range;
+                for (li, lo) in old_offsets.iter().enumerate() {
+                    let os = r.start.max(lo.start);
+                    let oe = r.end.min(lo.end);
+                    if os < oe {
+                        old_pending[li].push(InlineChange { byte_range: (os - lo.start)..(oe - lo.start) });
+                    }
+                }
+            }
+            for (li, ranges) in old_pending.iter_mut().enumerate() {
+                if ranges.is_empty() {
+                    continue;
+                }
+                if let DiffLine::Deletion {
+                    ref mut inline_highlights,
+                    ..
+                } = &mut lines[del_start + li]
+                {
+                    if inline_highlights.is_empty() {
+                        *inline_highlights = merge_inline_changes(std::mem::take(ranges));
+                    }
+                }
+            }
+
+            // Distribute new ranges to individual addition lines
+            let mut new_pending: Vec<Vec<InlineChange>> = (0..add_count).map(|_| Vec::new()).collect();
+            for change in &new_changes {
+                let r = &change.byte_range;
+                for (li, lo) in new_offsets.iter().enumerate() {
+                    let os = r.start.max(lo.start);
+                    let oe = r.end.min(lo.end);
+                    if os < oe {
+                        new_pending[li].push(InlineChange { byte_range: (os - lo.start)..(oe - lo.start) });
+                    }
+                }
+            }
+            for (li, ranges) in new_pending.iter_mut().enumerate() {
+                if ranges.is_empty() {
+                    continue;
+                }
+                if let DiffLine::Addition {
+                    ref mut inline_highlights,
+                    ..
+                } = &mut lines[add_start + li]
+                {
+                    if inline_highlights.is_empty() {
+                        *inline_highlights = merge_inline_changes(std::mem::take(ranges));
+                    }
+                }
+            }
+
+            // Merge per-line highlights
+            for i in del_start..(del_start + del_count) {
+                if let DiffLine::Deletion {
+                    ref mut inline_highlights,
+                    ..
+                } = &mut lines[i]
+                {
+                    if !inline_highlights.is_empty() {
+                        *inline_highlights = merge_inline_changes(std::mem::take(inline_highlights));
+                    }
+                }
+            }
+            for i in add_start..(add_start + add_count) {
+                if let DiffLine::Addition {
+                    ref mut inline_highlights,
+                    ..
+                } = &mut lines[i]
+                {
+                    if !inline_highlights.is_empty() {
+                        *inline_highlights = merge_inline_changes(std::mem::take(inline_highlights));
+                    }
+                }
+            }
+            }
+        }
+
         hunks.push(Hunk {
             before_lines: (hunk.before.start as usize)..(hunk.before.end as usize),
             after_lines: (hunk.after.start as usize)..(hunk.after.end as usize),
@@ -245,6 +773,7 @@ pub fn compute(
 #[derive(TaskerContext)]
 pub struct FullDiffContext {
     pub algorithm: DiffAlgorithm,
+    pub inline_diff: Arc<RwLock<bool>>,
 }
 
 impl Listener<FullDiffReq, crate::worker::EventSender> for FullDiff {
@@ -293,7 +822,7 @@ impl Listener<FullDiffReq, crate::worker::EventSender> for FullDiff {
                     return Ok(());
                 }
 
-                match compute(&ctx.algorithm, &left_text, &right_text, &event.node_path) {
+                match compute(&ctx.algorithm, &left_text, &right_text, &event.node_path, *ctx.inline_diff.read()) {
                     Ok(hunks) => DiffResult::Text(FileDiff {
                         old_text: Arc::from(left_text),
                         new_text: Arc::from(right_text),
@@ -326,13 +855,24 @@ impl Listener<FullDiffRes, crate::worker::EventSender> for FullDiffResListener {
     type Context = FullDiffResCtx;
 
     async fn handle(
-        event: FullDiffRes,
+        mut event: FullDiffRes,
         ctx: Self::Context,
         tx: crate::worker::EventSender,
     ) -> eyre::Result<()> {
         tracing::debug!(node_path = %event.node_path.display(), "Applied FullDiff cache");
 
         let mut cache = ctx.cache.write();
+
+        // Preserve line_selections (staging state) from the previous cached diff,
+        // so re-queueing doesn't lose user staging choices.
+        let old_selections = cache.diffs.get(&event.node_path).value().and_then(|d| {
+            if let crate::diff::DiffResult::Text(fd) = d {
+                Some(fd.line_selections.clone())
+            } else {
+                None
+            }
+        });
+
         if let crate::diff::DiffResult::Text(ref file_diff) = event.result {
             let text = file_diff.new_text.clone();
             cache.syntax.mark_started(event.node_path.clone());
@@ -345,6 +885,12 @@ impl Listener<FullDiffRes, crate::worker::EventSender> for FullDiffResListener {
                     right_path: event.right_path.clone(),
                     theme: val.clone(),
                 });
+            }
+        }
+
+        if let crate::diff::DiffResult::Text(ref mut new_diff) = event.result {
+            if let Some(selections) = old_selections {
+                new_diff.line_selections = selections;
             }
         }
 


### PR DESCRIPTION
When viewing a diff hunk, individual characters that differ between
corresponding - (deleted) and + (added) lines are now highlighted with a
distinct background color.
`d` can be pressed to toggle the diff highlight, and the feature can be disabled in the config.

<img width="648" height="425" alt="image" src="https://github.com/user-attachments/assets/c5a70004-90ff-4365-b82e-147bc865a783" />

NB: This is a mostly LLM-coded proof of concept. Feel free to keep it or discard it :)