### PR TITLE
feat: add per-line staging toggle with `t` key

### DIFF
--- a/crates/oyui/src/actions/define.rs
+++ b/crates/oyui/src/actions/define.rs
@@ -57,6 +57,7 @@ define_actions! {
             staging {
                 toggle(),
                 toggle_hunk(u32),
+                toggle_line(),
                 split(),
                 invert(),
             },

--- a/crates/oyui/src/actions/handlers/view_handlers/file_handler.rs
+++ b/crates/oyui/src/actions/handlers/view_handlers/file_handler.rs
@@ -515,6 +515,72 @@ impl ViewFileStagingActionsHandler for AppActionsHandler {
         }
     }
 
+    fn toggle_line(&self) {
+        let view = self.view.file_view.read();
+        if let Some(ctx) = get_file_context(&view) {
+            if let Some(mappings) = view.row_to_hunk.get(&ctx.path) {
+                if let Some(Some(hunk_idx)) = mappings.get(ctx.current_row_idx) {
+                    let hidx = *hunk_idx;
+                    if let Some(hunk_visual_start) = mappings.iter().position(|&h| h == Some(hidx))
+                    {
+                        drop(view);
+                        let line_within_hunk =
+                            ctx.current_row_idx.saturating_sub(hunk_visual_start);
+
+                        let mut diff_clone = None;
+                        if let Some(val) = self.cache.read().diffs.get(&ctx.path).value() {
+                            diff_clone = Some(val.clone());
+                        }
+
+                        if let Some(mut diff_result) = diff_clone {
+                            if let crate::diff::DiffResult::Text(ref mut diff) = diff_result {
+                                let total_lines: usize =
+                                    diff.hunks.iter().map(|h| h.lines.len()).sum();
+                                let default_staged = self
+                                    .tree
+                                    .read()
+                                    .get_file_state(&ctx.path)
+                                    .unwrap_or(crate::tree::StagingState::Unstaged)
+                                    == crate::tree::StagingState::Staged;
+
+                                if diff.line_selections.len() != total_lines {
+                                    diff.line_selections.resize(total_lines, default_staged);
+                                }
+
+                                let mut start_idx = 0;
+                                for hunk in diff.hunks.iter().take(hidx) {
+                                    start_idx += hunk.lines.len();
+                                }
+
+                                let global_idx = start_idx + line_within_hunk;
+
+                                if let Some(line) = diff.hunks[hidx].lines.get(line_within_hunk) {
+                                    if matches!(
+                                        line,
+                                        crate::diff::DiffLine::Addition { .. }
+                                            | crate::diff::DiffLine::Deletion { .. }
+                                    ) && global_idx < diff.line_selections.len()
+                                    {
+                                        diff.line_selections[global_idx] =
+                                            !diff.line_selections[global_idx];
+                                    }
+                                }
+
+                                update_tree_staging_state(
+                                    &self.tree,
+                                    &ctx.path,
+                                    diff,
+                                    default_staged,
+                                );
+                            }
+                            self.cache.write().diffs.set(ctx.path.clone(), diff_result);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn split(&self) {
         let view = self.view.file_view.read();
         if let Some(ctx) = get_file_context(&view) {

--- a/crates/oyui/src/actions/keybinds.rs
+++ b/crates/oyui/src/actions/keybinds.rs
@@ -205,6 +205,7 @@ pub fn default_keybinds() -> KeybindRegistry {
             .register(Keybinds::char('n'), ViewFileNavActions::next_hunk)
             .register(Keybinds::char('N'), ViewFileNavActions::prev_hunk)
             .register(Keybinds::char(' '), ViewFileStagingActions::toggle)
+            .register(Keybinds::char('t'), ViewFileStagingActions::toggle_line)
             .register(Keybinds::char('s'), ViewFileStagingActions::split)
             .register(Keybinds::char('i'), ViewFileStagingActions::invert)
             .register(Keybinds::char('z'), ViewFileFoldActions::toggle)


### PR DESCRIPTION
Allow staging/unstaging individual lines in the file diff view by pressing `t`. Previously only whole-hunk toggling was available (via space). 
That's a feature I like in jj's default :builtin diff editor!

NB: This is a mostly LLM-coded proof of concept. Feel free to keep it or discard it :)